### PR TITLE
remove checksum TODO

### DIFF
--- a/pkg/internal/app/grpc.go
+++ b/pkg/internal/app/grpc.go
@@ -153,8 +153,6 @@ func (app *demoApp) OpenInApp(
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	accessToken, err := token.SignedString([]byte(app.Config.WopiSecret))
 
-	// TODO: use checksum!
-
 	if err != nil {
 		return &appproviderv1beta1.OpenInAppResponse{
 			Status: &rpcv1beta1.Status{Code: rpcv1beta1.Code_CODE_INTERNAL},


### PR DESCRIPTION
The checksum of the filed is already used in https://github.com/wkloucek/cs3-wopi-server/blob/77cd0ec98965e12990ed6a150d9281a91f56e05c/pkg/internal/app/grpc.go#L54-L59

So I'm no longer sure what else we could get a checksum of...


